### PR TITLE
NavLink sets props types

### DIFF
--- a/lib/NavLink.js
+++ b/lib/NavLink.js
@@ -10,6 +10,9 @@ var React = require('react/addons'),
     debug = require('debug')('NavLink');
 
 NavLink = React.createClass({
+    propTypes: {
+      context: React.PropTypes.object.isRequired
+    },
     dispatchNavAction: function (e) {
         var context = this.props.context;
         debug('dispatchNavAction: action=NAVIGATE path=' + this.props.href + ' params=' + JSON.stringify(this.props.navParams));


### PR DESCRIPTION
The NavLink requires context to be passed via props and should make this explicit by setting it as a propType.
