### PR TITLE
Update react to v0.12

### DIFF
--- a/lib/NavLink.js
+++ b/lib/NavLink.js
@@ -34,12 +34,10 @@ NavLink = React.createClass({
         if (!this.props.href && routeName && context && context.makePath) {
             this.props.href = context.makePath(routeName, this.props.navParams);
         }
-        return this.transferPropsTo(
-            React.DOM.a(
+        return React.DOM.a(
                 {onClick:this.dispatchNavAction, href:this.props.href},
                 this.props.children
-            )
-        );
+            );        
     }
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-router-component",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Router-related React component and mixin for applications with Flux architecture",
   "main": "index.js",
   "repository": {
@@ -22,7 +22,7 @@
   "dependencies": {
     "debug": "^2.0.0",
     "query-string": "^1.0.0",
-    "react": "^0.11.1"
+    "react": "^0.12.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",
@@ -36,7 +36,7 @@
     "lodash": "^2.4.1",
     "mocha": "^1.20.0",
     "precommit-hook": "^1.0.2",
-    "react-tools": "^0.11.1"
+    "react-tools": "^0.12.0"
   },
   "jshintConfig": {
     "node": true


### PR DESCRIPTION
- update React to v0.12

Deprecated `transferPropsTo`:
https://gist.github.com/sebmarkbage/a6e220b7097eb3c79ab7
