### PR TITLE
[resolves #41] Merge in fluxible plugin and rename to fluxible-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,47 @@
-# flux-router-component [![Build Status](https://travis-ci.org/yahoo/flux-router-component.svg?branch=master)](https://travis-ci.org/yahoo/flux-router-component) [![Dependency Status](https://david-dm.org/yahoo/flux-router-component.svg)](https://david-dm.org/yahoo/flux-router-component) [![Coverage Status](https://coveralls.io/repos/yahoo/flux-router-component/badge.png?branch=master)](https://coveralls.io/r/yahoo/flux-router-component?branch=master)
-This package provides navigational React components and router React mixin for applications built with [Flux](http://facebook.github.io/react/docs/flux-overview.html) architecture.  Please check out [examples](https://github.com/yahoo/flux-router-component/tree/master/examples) of how to use these components.
+# fluxible-router 
+[![Build Status](https://travis-ci.org/yahoo/fluxible-router.svg?branch=master)](https://travis-ci.org/yahoo/fluxible-router) [![Dependency Status](https://david-dm.org/yahoo/fluxible-router.svg)](https://david-dm.org/yahoo/fluxible-router) [![Coverage Status](https://coveralls.io/repos/yahoo/fluxible-router/badge.png?branch=master)](https://coveralls.io/r/yahoo/fluxible-router?branch=master)
+This package provides navigational React components and router React mixin for applications built with [Flux](http://facebook.github.io/react/docs/flux-overview.html) architecture.  Please check out [examples](https://github.com/yahoo/fluxible-router/tree/master/examples) of how to use these components.
 
-## NavLink
+## Fluxible Plugin
+
+For use with [fluxible-app](https://github.com/yahoo/fluxible-app):
+
+```js
+var FluxibleApp = require('fluxible-app');
+var routerPlugin = require('fluxible-router').plugin;
+var app = new FluxibleApp();
+
+var pluginInstance = routerPlugin({
+    routes: {
+        user: {
+            path: '/user/:id',
+            method: 'get',
+            // the navigate action will execute this action when the route is matched
+            action: function (actionContext, payload, done) {
+                // ...
+                done();
+            }
+        }
+    }
+});
+
+app.plug(pluginInstance);
+```
+
+Adds the following methods to your fluxible contexts:
+
+ * `actionContext.router.makePath(routeName, routeParams)`: Create a URL based on route name and params
+ * `actionContext.router.getRoute(path)`: Returns matched route
+ * `componentContext.makePath(routeName, routeParams)`: Create a URL based on route name and params
+
+## NavLink Component
+
 `NavLink` is the a React component for navigational links.  When the link is clicked, NavLink will dispatch `NAVIGATE` action to flux dispatcher.  The dispatcher can then dispatch the action to the stores that can handle it.
 
-### Example Usage
 Example of using `NavLink` with `href` property defined:
+
 ```js
-var NavLink = require('flux-router-component').NavLink;
+var NavLink = require('fluxible-router').NavLink;
 
 var Nav = React.createClass({
     render: function () {
@@ -48,6 +82,7 @@ var Nav = React.createClass({
 We also have another more sophisticated example application, [routing](https://github.com/yahoo/flux-examples/tree/master/routing), that uses `NavLink` with `routeName` property defined.
 
 ## RouterMixin
+
 `RouterMixin` is a React mixin to be used by application's top level React component to:
 
 * [manage browser history](#history-management-browser-support-and-hash-based-routing) when route changes, and
@@ -56,7 +91,7 @@ We also have another more sophisticated example application, [routing](https://g
 
 ### Example Usage
 ```js
-var RouterMixin = require('flux-router-component').RouterMixin;
+var RouterMixin = require('fluxible-router').RouterMixin;
 
 var Application = React.createClass({
     mixins: [RouterMixin],
@@ -181,7 +216,7 @@ You can also look into this [polyfill.io polyfill service](https://cdn.polyfill.
 This software is free to use under the Yahoo! Inc. BSD license.
 See the [LICENSE file][] for license text and copyright information.
 
-[LICENSE file]: https://github.com/yahoo/flux-router-component/blob/master/LICENSE.md
+[LICENSE file]: https://github.com/yahoo/fluxible-router/blob/master/LICENSE.md
 
-Third-pary open source code used are listed in our [package.json file]( https://github.com/yahoo/flux-router-component/blob/master/package.json).
+Third-pary open source code used are listed in our [package.json file]( https://github.com/yahoo/fluxible-router/blob/master/package.json).
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 'use strict';
 
 module.exports = {
+    plugin: require('./lib/router-plugin'),
     NavLink: require('./lib/NavLink'),
     RouterMixin: require('./lib/RouterMixin'),
     navigateAction: require('./actions/navigate'),

--- a/lib/router-plugin.js
+++ b/lib/router-plugin.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2014, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+var Router = require('routr');
+
+module.exports = function routerPlugin(options) {
+    options = options || {};
+    var routes = options.routes;
+    /**
+     * @class RouterPlugin
+     */
+    return {
+        name: 'RouterPlugin',
+        /**
+         * Called to plug the FluxContext
+         * @method plugContext
+         * @returns {Object}
+         */
+        plugContext: function plugContext() {
+            var router = new Router(routes);
+            return {
+                /**
+                 * Provides full access to the router in the action context
+                 * @param {Object} actionContext
+                 */
+                plugActionContext: function plugActionContext(actionContext) {
+                    actionContext.router = router;
+                },
+                /**
+                 * Provides access to create paths by name
+                 * @param {Object} componentContext
+                 */
+                plugComponentContext: function plugComponentContext(componentContext) {
+                    componentContext.makePath = router.makePath.bind(router);
+                }
+            };
+        },
+        /**
+         * @method getRoutes
+         * @returns {Object}
+         */
+        getRoutes: function getRoutes() {
+            return routes;
+        }
+    };
+};

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "flux-router-component",
-  "version": "0.4.3",
-  "description": "Router-related React component and mixin for applications with Flux architecture",
+  "name": "fluxible-router",
+  "version": "0.1.0",
+  "description": "Routing support for Fluxible applications",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/yahoo/flux-router-component.git"
+    "url": "git://github.com/yahoo/fluxible-router.git"
   },
   "scripts": {
     "cover": "node node_modules/istanbul/lib/cli.js cover --dir artifacts -- ./node_modules/mocha/bin/_mocha tests/unit/ --recursive --reporter spec",
@@ -16,7 +16,7 @@
   "licenses": [
     {
       "type": "BSD",
-      "url": "https://github.com/yahoo/flux-router-component/blob/master/LICENSE.md"
+      "url": "https://github.com/yahoo/fluxible-router/blob/master/LICENSE.md"
     }
   ],
   "dependencies": {
@@ -24,11 +24,13 @@
     "object-assign": "^1.0.0",
     "query-string": "^1.0.0",
     "react": "^0.12.0",
+    "routr": "^0.0.x",
     "setimmediate": "^1.0.2"
   },
   "devDependencies": {
     "chai": "^1.9.1",
     "coveralls": "^2.11.1",
+    "fluxible-app": "^0.1.0",
     "grunt": "^0.4.0",
     "grunt-cli": "^0.1.0",
     "grunt-react": "^0.8.0",
@@ -45,6 +47,7 @@
   },
   "keywords": [
     "flux",
+    "fluxible",
     "history",
     "navigation",
     "react",

--- a/tests/unit/lib/NavLink-test.js
+++ b/tests/unit/lib/NavLink-test.js
@@ -47,7 +47,7 @@ describe('NavLink', function () {
         global.navigator = global.window.navigator;
         React = require('react/addons');
         ReactTestUtils = React.addons.TestUtils;
-        NavLink = React.createFactory(require('../../../lib/NavLink'));
+        NavLink = React.createFactory(require('../../../').NavLink);
         testResult = {};
     });
 

--- a/tests/unit/lib/RouterMixin-test.js
+++ b/tests/unit/lib/RouterMixin-test.js
@@ -41,7 +41,7 @@ historyMock = function (path) {
 describe ('RouterMixin', function () {
 
     beforeEach(function () {
-        routerMixin = require('../../../lib/RouterMixin');
+        routerMixin = require('../../../').RouterMixin;
         routerMixin.props = {context: contextMock};
         routerMixin.state = {
             route: {}

--- a/tests/unit/lib/router-plugin-test.js
+++ b/tests/unit/lib/router-plugin-test.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2014, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+/*globals describe,it,beforeEach */
+"use strict";
+
+var expect = require('chai').expect;
+var routrPlugin = require('../../../').plugin;
+var FluxibleApp = require('fluxible-app');
+
+describe('RouterPlugin', function () {
+    var app,
+        pluginInstance,
+        context,
+        routes = {
+            view_user: {
+                path: '/user/:id',
+                method: 'get',
+                foo: {
+                    bar: 'baz'
+                }
+            },
+            view_user_post: {
+                path: '/user/:id/post/:post',
+                method: 'get'
+            }
+        };
+
+    beforeEach(function () {
+        app = new FluxibleApp();
+        pluginInstance = routrPlugin({
+            routes: routes
+        });
+        app.plug(pluginInstance);
+        context = app.createContext();
+    });
+
+    describe('factory', function () {
+        it('should accept routes option', function () {
+            expect(pluginInstance.getRoutes()).to.deep.equal(routes);
+        });
+    });
+
+    describe('actionContext', function () {
+        var actionContext;
+        beforeEach(function () {
+            actionContext = context.getActionContext();
+        });
+        describe('router', function () {
+            it('should have a router access', function () {
+                expect(actionContext.router).to.be.an('object');
+                expect(actionContext.router.makePath).to.be.a('function');
+                expect(actionContext.router.getRoute).to.be.a('function');
+                expect(actionContext.router.makePath('view_user', {id: 1})).to.equal('/user/1');
+            });
+        });
+    });
+
+    describe('componentContext', function () {
+        var componentContext;
+        beforeEach(function () {
+            componentContext = context.getComponentContext();
+        });
+        describe('router', function () {
+            it('should have a router access', function () {
+                expect(componentContext.makePath).to.be.a('function');
+                expect(componentContext.makePath('view_user', {id: 1})).to.equal('/user/1');
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
This combines the flux-router-component and fluxible-plugin-routr to form a cohesive routing solution for fluxible apps. flux-router-component relied too much on the fluxible interface to be real useful otherwise. This should make it easier for a developer to get routing up and running on a fluxible application without have to jump between multiple instructions to get a full solution up and running.