### PR TITLE
Use apply()

### DIFF
--- a/lib/History.js
+++ b/lib/History.js
@@ -74,7 +74,7 @@ History.prototype = {
     pushState: function (state, title, url) {
         var win = this.win;
         if (this._hasPushState) {
-            win.history.pushState(state, title, url);
+            win.history.pushState.apply(null, arguments);
         } else if (url) {
             win.location.href = url;
         }
@@ -90,7 +90,7 @@ History.prototype = {
     replaceState: function (state, title, url) {
         var win = this.win;
         if (this._hasPushState) {
-            win.history.replaceState(state, title, url);
+            win.history.replaceState.apply(null, arguments);
         } else if (url) {
             win.location.replace(url);
         }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-cli": "^0.1.0",
     "grunt-react": "^0.10.0",
     "istanbul": "^0.3.2",
-    "jsdom": "^1.3.1",
+    "jsdom": "^2.0.0",
     "jshint": "^2.5.1",
     "lodash": "^2.4.1",
     "mocha": "^2.0.1",

--- a/tests/unit/lib/History-test.js
+++ b/tests/unit/lib/History-test.js
@@ -194,6 +194,11 @@ describe('History', function () {
         it ('has pushState', function () {
             var history = new History({win: windowMock.HTML5});
 
+            history.pushState({foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({foo: 'bar'});
+            expect(testResult.pushState.title).to.equal(undefined);
+            expect(testResult.pushState.url).to.equal(undefined);
+
             history.pushState({foo: 'bar'}, 't', '/url');
             expect(testResult.pushState.state).to.eql({foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
@@ -224,6 +229,12 @@ describe('History', function () {
     describe('replaceState', function () {
         it ('has pushState', function () {
             var history = new History({win: windowMock.HTML5});
+
+            history.replaceState({foo: 'bar'});
+            expect(testResult.replaceState.state).to.eql({foo: 'bar'});
+            expect(testResult.replaceState.title).to.equal(undefined);
+            expect(testResult.replaceState.url).to.equal(undefined);
+
             history.replaceState({foo: 'bar'}, 't', '/url');
             expect(testResult.replaceState.state).to.eql({foo: 'bar'});
             expect(testResult.replaceState.title).to.equal('t');

--- a/tests/unit/utils/HistoryWithHash-test.js
+++ b/tests/unit/utils/HistoryWithHash-test.js
@@ -223,6 +223,11 @@ describe('HistoryWithHash', function () {
         it ('useHashRoute=false; has pushState', function () {
             var history = new HistoryWithHash({win: windowMock.HTML5});
 
+            history.pushState({foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({foo: 'bar'});
+            expect(testResult.pushState.title).to.equal(undefined);
+            expect(testResult.pushState.url).to.equal(undefined);
+
             history.pushState({foo: 'bar'}, 't', '/url');
             expect(testResult.pushState.state).to.eql({foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
@@ -309,6 +314,12 @@ describe('HistoryWithHash', function () {
     describe('replaceState', function () {
         it ('useHashRouter=false; has pushState', function () {
             var history = new HistoryWithHash({win: windowMock.HTML5});
+
+            history.replaceState({foo: 'bar'});
+            expect(testResult.replaceState.state).to.eql({foo: 'bar'});
+            expect(testResult.replaceState.title).to.equal(undefined);
+            expect(testResult.replaceState.url).to.equal(undefined);
+
             history.replaceState({foo: 'bar'}, 't', '/url');
             expect(testResult.replaceState.state).to.eql({foo: 'bar'});
             expect(testResult.replaceState.title).to.equal('t');

--- a/utils/HistoryWithHash.js
+++ b/utils/HistoryWithHash.js
@@ -135,7 +135,7 @@ HistoryWithHash.prototype = {
             }
         } else {
             if (this._hasPushState) {
-                history.pushState(state, title, url);
+                history.pushState.apply(null, arguments);
             } else if (url) {
                 location.href = url;
             }
@@ -170,7 +170,7 @@ HistoryWithHash.prototype = {
             }
         } else {
             if (this._hasPushState) {
-                history.replaceState(state, title, url);
+                history.replaceState.apply(null, arguments);
             } else if (url) {
                 location.replace(url);
             }


### PR DESCRIPTION
@mridgway @redonkulus 
To be safe, use apply(), instead of autofilling with `undefined`, when `history.pushState()` or `history.replaceState()` is called with less than 3 args.  Some old browsers might replace url with `undefined` if `undefined` is passed explicitly for the last `url` parameter.  Lets see if this addresses https://github.com/yahoo/flux-router-component/issues/56.

Also updated jsdom devDependency.