### PR TITLE
NavLink: only navigate on unmodified clicks

### DIFF
--- a/lib/NavLink.js
+++ b/lib/NavLink.js
@@ -11,6 +11,14 @@ var navigateAction = require('../actions/navigate');
 var debug = require('debug')('NavLink');
 var objectAssign = require('object-assign');
 
+function isLeftClickEvent (e) {
+    return e.button === 0;
+}
+
+function isModifiedEvent (e) {
+    return !!(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey);
+}
+
 NavLink = React.createClass({
     displayName: 'NavLink',
     contextTypes: {
@@ -22,6 +30,12 @@ NavLink = React.createClass({
     },
     dispatchNavAction: function (e) {
         debug('dispatchNavAction: action=NAVIGATE', this.props.href, this.props.navParams);
+
+        if (isModifiedEvent(e) || !isLeftClickEvent(e)) {
+            // this is a click with a modifier or not a left-click
+            // let browser handle it natively
+            return;
+        }
 
         var href = this.props.href;
 

--- a/tests/unit/lib/NavLink-test.js
+++ b/tests/unit/lib/NavLink-test.js
@@ -92,7 +92,7 @@ describe('NavLink', function () {
             var navParams = {a: 1, b: true};
             var link = ReactTestUtils.renderIntoDocument(NavLink( {href:"/foo", navParams:navParams}, React.DOM.span(null, "bar")));
             link.context = contextMock;
-            ReactTestUtils.Simulate.click(link.getDOMNode());
+            ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
             window.setTimeout(function () {
                 expect(testResult.dispatch.action).to.equal('NAVIGATE');
                 expect(testResult.dispatch.payload.type).to.equal('click');
@@ -104,7 +104,7 @@ describe('NavLink', function () {
         it ('context.executeAction called for relative urls', function (done) {
             var navParams = {a: 1, b: true};
             var link = ReactTestUtils.renderIntoDocument(NavLink( {href:"/foo", context:contextMock, navParams:navParams}, React.DOM.span(null, "bar")));
-            ReactTestUtils.Simulate.click(link.getDOMNode());
+            ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
             window.setTimeout(function () {
                 expect(testResult.dispatch.action).to.equal('NAVIGATE');
                 expect(testResult.dispatch.payload.type).to.equal('click');
@@ -117,7 +117,7 @@ describe('NavLink', function () {
             var navParams = {a: 1, b: true};
             var origin = window.location.origin;
             var link = ReactTestUtils.renderIntoDocument(NavLink( {href: origin + "/foo?x=y", context:contextMock, navParams:navParams}, React.DOM.span(null, "bar")));
-            ReactTestUtils.Simulate.click(link.getDOMNode());
+            ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
             window.setTimeout(function () {
                 expect(testResult.dispatch.action).to.equal('NAVIGATE');
                 expect(testResult.dispatch.payload.type).to.equal('click');
@@ -129,7 +129,7 @@ describe('NavLink', function () {
         it ('context.executeAction not called if context does not exist', function (done) {
             var navParams = {a: 1, b: true};
             var link = ReactTestUtils.renderIntoDocument(NavLink( {href:"/foo", navParams:navParams}, React.DOM.span(null, "bar")));
-            ReactTestUtils.Simulate.click(link.getDOMNode());
+            ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
             window.setTimeout(function () {
                 expect(testResult.dispatch).to.equal(undefined);
                 done();
@@ -138,7 +138,7 @@ describe('NavLink', function () {
         it ('context.executeAction not called for external urls', function (done) {
             var navParams = {a: 1, b: true};
             var link = ReactTestUtils.renderIntoDocument(NavLink( {href:"http://domain.does.not.exist/foo", navParams:navParams}, React.DOM.span(null, "bar")));
-            ReactTestUtils.Simulate.click(link.getDOMNode());
+            ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
             window.setTimeout(function () {
                 expect(testResult.dispatch).to.equal(undefined);
                 done();
@@ -147,7 +147,7 @@ describe('NavLink', function () {
         it ('context.executeAction not called for # urls', function (done) {
             var navParams = {a: 1, b: true};
             var link = ReactTestUtils.renderIntoDocument(NavLink( {href:"#here", navParams:navParams}, React.DOM.span(null, "bar")));
-            ReactTestUtils.Simulate.click(link.getDOMNode());
+            ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
             window.setTimeout(function () {
                 expect(testResult.dispatch).to.equal(undefined);
                 done();
@@ -155,11 +155,39 @@ describe('NavLink', function () {
         });
     });
 
+    describe('click type', function () {
+        it('navigates on regular click', function (done) {
+                var origin = window.location.origin;
+                var link = ReactTestUtils.renderIntoDocument(NavLink( {href: origin, context:contextMock}, React.DOM.span(null, "bar")));
+                ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
+                window.setTimeout(function () {
+                    expect(testResult.dispatch.action).to.equal('NAVIGATE');
+                    expect(testResult.dispatch.payload.type).to.equal('click');
+                    done();
+                }, 10);
+        });
+
+        ['metaKey', 'altKey', 'ctrlKey', 'shiftKey'].map(function (key) {
+            it('does not navigate on modified ' + key, function (done) {
+                    var eventData = {button: 0};
+                    eventData[key] = true;
+                    var origin = window.location.origin;
+                    var link = ReactTestUtils.renderIntoDocument(NavLink( {href: origin, context:contextMock}, React.DOM.span(null, "bar")));
+                    ReactTestUtils.Simulate.click(link.getDOMNode(), eventData);
+                    window.setTimeout(function () {
+                        expect(testResult.dispatch).to.equal(undefined);
+                        done();
+                    }, 10);
+            });
+        });
+
+    });
+
     it('allow overriding onClick', function (done) {
         var navParams = {a: 1, b: true};
         var link = ReactTestUtils.renderIntoDocument(NavLink( {href:"/foo", context:contextMock, navParams:navParams, onClick: onClickMock}, React.DOM.span(null, "bar")));
         expect(testResult.onClickMockInvoked).to.equal(undefined);
-        ReactTestUtils.Simulate.click(link.getDOMNode());
+        ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
         window.setTimeout(function () {
             expect(testResult.dispatch).to.equal(undefined);
             expect(testResult.onClickMockInvoked).to.equal(true);


### PR DESCRIPTION
It's annoying that NavLink swallows command+click, which is meant to open the link in a new tab.
Shamelessly copied from react-router's [Link](https://github.com/rackt/react-router/blob/f24328cced95fd2e215cfcda6716ffa298ea556e/modules/components/Link.js#L61) component.