### PR TITLE
allow react 0.13 rc releases. can't use <=0.13.x or <0.14.0 because of npm 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "setimmediate": "^1.0.2"
   },
   "peerDependencies": {
-    "react": ">=0.12.0 <=0.13.0-beta.x"
+    "react": ">=0.12.0 <=0.13.0-rcx"
   },
   "devDependencies": {
     "chai": "^2.0.0",
@@ -37,8 +37,8 @@
     "lodash": "^3.2.0",
     "mocha": "^2.0.1",
     "precommit-hook": "^1.0.2",
-    "react": ">=0.12.0 <=0.13.0-beta.x",
-    "react-tools": ">=0.12.0 <=0.13.0-beta.x"
+    "react": ">=0.12.0 <=0.13.0-rcx",
+    "react-tools": ">=0.12.0 <=0.13.0-rcx"
   },
   "jshintConfig": {
     "node": true


### PR DESCRIPTION
@redonkulus addresses #77 