### PR TITLE
Provide childContext functions in RouterMixin

### DIFF
--- a/lib/RouterMixin.js
+++ b/lib/RouterMixin.js
@@ -35,6 +35,16 @@ RouterMixin = {
         executeAction: React.PropTypes.func,
         makePath: React.PropTypes.func
     },
+    childContextTypes: {
+        makePath: React.PropTypes.func
+    },
+    getChildContext: function(){
+        var context = {};
+        Object.keys(RouterMixin.childContextTypes).forEach(function (key) {
+            context[key] = (this.props.context && this.props.context[key]) || this.context[key];
+        }, this);
+        return context;
+    },
     componentDidMount: function() {
         var self = this;
         var context;

--- a/tests/unit/lib/RouterMixin-test.js
+++ b/tests/unit/lib/RouterMixin-test.js
@@ -19,7 +19,8 @@ contextMock = {
             action: action,
             payload: payload
         };
-    }
+    },
+    makePath: function(){}
 };
 
 historyMock = function (url, state) {
@@ -76,9 +77,23 @@ describe ('RouterMixin', function () {
         delete global.navigator;
     });
 
-    it('contextType defined', function () {
+    it('contextTypes defined', function () {
         expect(routerMixin.contextTypes.executeAction).to.equal(React.PropTypes.func);
         expect(routerMixin.contextTypes.makePath).to.equal(React.PropTypes.func);
+    });
+
+    it('childContextTypes defined', function () {
+        expect(routerMixin.childContextTypes.makePath).to.equal(React.PropTypes.func);
+    });
+
+    describe('getChildContext()', function() {
+        it ('exposes childContextTypes to child context', function() {
+            routerMixin.props = {context: contextMock };
+            var childContext = routerMixin.getChildContext();
+            Object.keys(routerMixin.childContextTypes).forEach(function (key) {
+              expect(childContext[key]).to.be.a('function');
+            }, this);
+        });
     });
 
     describe('componentDidMount()', function () {


### PR DESCRIPTION
To coincide with the child context changes in fluxible, expose router
specific functions to the child context.

See https://github.com/yahoo/fluxible/pull/52