### PR TITLE
document title and followLink

### DIFF
--- a/docs/navlink.md
+++ b/docs/navlink.md
@@ -1,6 +1,14 @@
 # NavLink
 `NavLink` is the a React component for navigational links.  When the link is clicked, NavLink will dispatch `NAVIGATE` action to flux dispatcher.  The dispatcher can then dispatch the action to the stores that can handle it.
 
+| Prop Name | Prop Type | Description |
+|------------|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| href | String | The url string |
+| routeName | String | Not used if `href` is specified. This is the name of the target route, which should be defined in your app's routes. |
+| navParams | Object | If `href` prop is not available, `navParams` object will be used together with `routeName` to generate the href for the link.  This object needs to contain route params the route path needs.  Eg. for a route path `/article/:id`, `navParams.id` will be the article ID. |
+| followLink | boolean, default to false | If set to true, client side navigation will be disabled.  NavLink will just act like a regular anchor link. |
+
+
 ## Example Usage
 
 Here are two examples of generating `NavLink` using `href` property, and using `routeName` property.  Using `href` property is better than using `routeName`, because:

--- a/lib/History.js
+++ b/lib/History.js
@@ -84,6 +84,7 @@ History.prototype = {
                     win.history.pushState(state, title, url);
                 }
             }
+            this.setTitle(title);
         } else if (url) {
             win.location.href = url;
         }
@@ -109,8 +110,19 @@ History.prototype = {
                     win.history.replaceState(state, title, url);
                 }
             }
+            this.setTitle(title);
         } else if (url) {
             win.location.replace(url);
+        }
+    },
+
+    /**
+     * Sets document title. No-op if title is empty.
+     * @param {String} title  The title string.
+     */
+    setTitle: function (title) {
+        if (title) {
+            this.win.document.title = title;
         }
     }
 };

--- a/lib/NavLink.js
+++ b/lib/NavLink.js
@@ -26,10 +26,18 @@ NavLink = React.createClass({
         makePath: React.PropTypes.func
     },
     propTypes: {
-        context: React.PropTypes.object
+        context: React.PropTypes.object,
+        href: React.PropTypes.string,
+        routeName: React.PropTypes.string,
+        navParams: React.PropTypes.object,
+        followLink: React.PropTypes.bool
     },
     dispatchNavAction: function (e) {
-        debug('dispatchNavAction: action=NAVIGATE', this.props.href, this.props.navParams);
+        debug('dispatchNavAction: action=NAVIGATE', this.props.href, this.props.followLink, this.props.navParams);
+
+        if (this.props.followLink) {
+            return;
+        }
 
         if (isModifiedEvent(e) || !isLeftClickEvent(e)) {
             // this is a click with a modifier or not a left-click

--- a/lib/RouterMixin.js
+++ b/lib/RouterMixin.js
@@ -122,20 +122,22 @@ RouterMixin = {
             return;
         }
 
-        var nav = newState.route.navigate;
-        var navType = (nav && nav.type) || TYPE_DEFAULT;
+        var nav = newState.route.navigate || {};
+        var navType = nav.type || TYPE_DEFAULT;
         var historyState;
+        var pageTitle;
 
         switch (navType) {
             case TYPE_CLICK:
             case TYPE_DEFAULT:
-                historyState = {params: (nav && nav.params) || {}};
+                historyState = {params: (nav.params || {})};
                 if (this._enableScroll) {
                     window.scrollTo(0, 0);
                     historyState.scroll = {x: 0, y: 0};
                     debug('on click navigation, reset scroll position to (0, 0)');
                 }
-                this._history.pushState(historyState, null, newState.route.url);
+                pageTitle = nav.params && nav.params.pageTitle || null;
+                this._history.pushState(historyState, pageTitle, newState.route.url);
                 break;
             case TYPE_POPSTATE:
                 if (this._enableScroll) {

--- a/tests/mocks/mockWindow.js
+++ b/tests/mocks/mockWindow.js
@@ -1,6 +1,7 @@
 module.exports = function mockWindow(testResult) {
     return {
         HTML5: {
+            document: {},
             history: {
                 pushState: function (state, title, url) {
                     testResult.pushState = {
@@ -31,6 +32,7 @@ module.exports = function mockWindow(testResult) {
             }
         },
         Firefox: {
+            document: {},
             history: {
                 pushState: function (state, title, url) {
                     if (arguments.length < 3) {
@@ -72,6 +74,7 @@ module.exports = function mockWindow(testResult) {
             }
         },
         OLD: {
+            document: {},
             addEventListener: function (evt, listener) {
                 testResult.addEventListener = {
                     evt: evt,

--- a/tests/unit/lib/History-test.js
+++ b/tests/unit/lib/History-test.js
@@ -163,11 +163,13 @@ describe('History', function () {
             expect(testResult.pushState.state).to.eql({foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
             expect(testResult.pushState.url).to.equal('/url');
+            expect(windowMock.HTML5.document.title).to.equal('t');
 
-            history.pushState({foo: 'bar'}, 't', '/url?a=b&x=y');
+            history.pushState({foo: 'bar'}, 'tt', '/url?a=b&x=y');
             expect(testResult.pushState.state).to.eql({foo: 'bar'});
-            expect(testResult.pushState.title).to.equal('t');
+            expect(testResult.pushState.title).to.equal('tt');
             expect(testResult.pushState.url).to.equal('/url?a=b&x=y');
+            expect(windowMock.HTML5.document.title).to.equal('tt');
         });
         it ('has pushState, Firefox', function () {
             var history = new History({win: windowMock.Firefox});
@@ -222,11 +224,13 @@ describe('History', function () {
             expect(testResult.replaceState.state).to.eql({foo: 'bar'});
             expect(testResult.replaceState.title).to.equal('t');
             expect(testResult.replaceState.url).to.equal('/url');
+            expect(windowMock.HTML5.document.title).to.equal('t');
 
-            history.replaceState({foo: 'bar'}, 't', '/url?a=b&x=y');
+            history.replaceState({foo: 'bar'}, 'tt', '/url?a=b&x=y');
             expect(testResult.replaceState.state).to.eql({foo: 'bar'});
-            expect(testResult.replaceState.title).to.equal('t');
+            expect(testResult.replaceState.title).to.equal('tt');
             expect(testResult.replaceState.url).to.equal('/url?a=b&x=y', 'url has query');
+            expect(windowMock.HTML5.document.title).to.equal('tt');
         });
         it ('has pushState, Firefox', function () {
             var history = new History({win: windowMock.Firefox});

--- a/tests/unit/lib/NavLink-test.js
+++ b/tests/unit/lib/NavLink-test.js
@@ -103,7 +103,8 @@ describe('NavLink', function () {
         });
         it ('context.executeAction called for relative urls', function (done) {
             var navParams = {a: 1, b: true};
-            var link = ReactTestUtils.renderIntoDocument(NavLink( {href:"/foo", context:contextMock, navParams:navParams}, React.DOM.span(null, "bar")));
+            var link = ReactTestUtils.renderIntoDocument(NavLink( {href:"/foo", navParams:navParams}, React.DOM.span(null, "bar")));
+            link.context = contextMock;
             ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
             window.setTimeout(function () {
                 expect(testResult.dispatch.action).to.equal('NAVIGATE');
@@ -116,7 +117,8 @@ describe('NavLink', function () {
         it ('context.executeAction called for absolute urls from same origin', function (done) {
             var navParams = {a: 1, b: true};
             var origin = window.location.origin;
-            var link = ReactTestUtils.renderIntoDocument(NavLink( {href: origin + "/foo?x=y", context:contextMock, navParams:navParams}, React.DOM.span(null, "bar")));
+            var link = ReactTestUtils.renderIntoDocument(NavLink( {href: origin + "/foo?x=y", navParams:navParams}, React.DOM.span(null, "bar")));
+            link.context = contextMock;
             ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
             window.setTimeout(function () {
                 expect(testResult.dispatch.action).to.equal('NAVIGATE');
@@ -150,6 +152,29 @@ describe('NavLink', function () {
             ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
             window.setTimeout(function () {
                 expect(testResult.dispatch).to.equal(undefined);
+                done();
+            }, 10);
+        });
+        it ('context.executeAction not called if followLink=true', function (done) {
+            var navParams = {a: 1, b: true};
+            var link = ReactTestUtils.renderIntoDocument(NavLink( {href:"/somepath", navParams:navParams, followLink:true}, React.DOM.span(null, "bar")));
+            link.context = contextMock;
+            ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
+            window.setTimeout(function () {
+                expect(testResult.dispatch).to.equal(undefined);
+                done();
+            }, 1000);
+        });
+        it ('context.executeAction called if followLink=false', function (done) {
+            var navParams = {a: 1, b: true};
+            var link = ReactTestUtils.renderIntoDocument(NavLink( {href:"/foo", navParams:navParams, followLink:false}, React.DOM.span(null, "bar")));
+            link.context = contextMock;
+            ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
+            window.setTimeout(function () {
+                expect(testResult.dispatch.action).to.equal('NAVIGATE');
+                expect(testResult.dispatch.payload.type).to.equal('click');
+                expect(testResult.dispatch.payload.url).to.equal('/foo');
+                expect(testResult.dispatch.payload.params).to.eql({a: 1, b: true});
                 done();
             }, 10);
         });

--- a/tests/unit/lib/RouterMixin-test.js
+++ b/tests/unit/lib/RouterMixin-test.js
@@ -52,7 +52,6 @@ historyMock = function (url, state) {
 };
 
 scrollToMock = function (x, y) {
-    console.log('scrollToMock', x, y);
     testResult.scrollTo = {x: x, y: y};
 };
 

--- a/tests/unit/utils/HistoryWithHash-test.js
+++ b/tests/unit/utils/HistoryWithHash-test.js
@@ -186,11 +186,13 @@ describe('HistoryWithHash', function () {
             expect(testResult.pushState.state).to.eql({foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
             expect(testResult.pushState.url).to.equal('/url');
+            expect(windowMock.HTML5.document.title).to.equal('t');
 
-            history.pushState({foo: 'bar'}, 't', '/url?a=b&x=y');
+            history.pushState({foo: 'bar'}, 'tt', '/url?a=b&x=y');
             expect(testResult.pushState.state).to.eql({foo: 'bar'});
-            expect(testResult.pushState.title).to.equal('t');
+            expect(testResult.pushState.title).to.equal('tt');
             expect(testResult.pushState.url).to.equal('/url?a=b&x=y');
+            expect(windowMock.HTML5.document.title).to.equal('tt');
         });
         it ('useHashRoute=false; has pushState; Firefox', function () {
             var history = new HistoryWithHash({win: windowMock.Firefox});
@@ -291,11 +293,13 @@ describe('HistoryWithHash', function () {
             expect(testResult.replaceState.state).to.eql({foo: 'bar'});
             expect(testResult.replaceState.title).to.equal('t');
             expect(testResult.replaceState.url).to.equal('/url');
+            expect(windowMock.HTML5.document.title).to.equal('t');
 
-            history.replaceState({foo: 'bar'}, 't', '/url?a=b&x=y');
+            history.replaceState({foo: 'bar'}, 'tt', '/url?a=b&x=y');
             expect(testResult.replaceState.state).to.eql({foo: 'bar'});
-            expect(testResult.replaceState.title).to.equal('t');
+            expect(testResult.replaceState.title).to.equal('tt');
             expect(testResult.replaceState.url).to.equal('/url?a=b&x=y', 'url has query');
+            expect(windowMock.HTML5.document.title).to.equal('tt');
         });
         it ('useHashRouter=false; has pushState; Firefox', function () {
             var history = new HistoryWithHash({win: windowMock.Firefox});

--- a/utils/HistoryWithHash.js
+++ b/utils/HistoryWithHash.js
@@ -130,6 +130,7 @@ HistoryWithHash.prototype = {
             if (this._hasPushState) {
                 url = hash ? location.pathname + location.search + hash : null;
                 history.pushState(state, title, url);
+                this.setTitle(title);
             } else if (hash) {
                 location.hash = hash;
             }
@@ -145,6 +146,7 @@ HistoryWithHash.prototype = {
                         history.pushState(state, title, url);
                     }
                 }
+                this.setTitle(title);
             } else if (url) {
                 location.href = url;
             }
@@ -173,6 +175,7 @@ HistoryWithHash.prototype = {
             if (this._hasPushState) {
                 url = hash ? (location.pathname + location.search + hash) : null;
                 history.replaceState(state, title, url);
+                this.setTitle(title);
             } else if (url) {
                 url = location.pathname + location.search + hash;
                 location.replace(url);
@@ -189,9 +192,20 @@ HistoryWithHash.prototype = {
                         history.replaceState(state, title, url);
                     }
                 }
+                this.setTitle(title);
             } else if (url) {
                 location.replace(url);
             }
+        }
+    },
+
+    /**
+     * Sets document title. No-op if title is empty.
+     * @param {String} title  The title string.
+     */
+    setTitle: function (title) {
+        if (title) {
+            this.win.document.title = title;
         }
     }
 };


### PR DESCRIPTION
* if pageTitle is available in navParams, update document title
* add followLink prop for NavLink.  If it is set to true, NavLink will behave like anchor link, with no client-side navigation.  This makes it easier for developers, so that they don't need to branch their react render code between `<NavLink>` and `<a>`.

@redonkulus @mridgway