### PR TITLE
Fix routeName not executing correctly

### DIFF
--- a/lib/NavLink.js
+++ b/lib/NavLink.js
@@ -32,6 +32,28 @@ NavLink = React.createClass({
         navParams: React.PropTypes.object,
         followLink: React.PropTypes.bool
     },
+    getInitialState: function () {
+        return {
+            href: this._getHrefFromProps(this.props)
+        };
+    },
+    componentWillReceiveProps: function (nextProps) {
+        this.setState({
+            href: this._getHrefFromProps(nextProps)
+        });
+    },
+    _getHrefFromProps: function (props) {
+        var href = props.href;
+        var routeName = props.routeName;
+        if (!href && routeName) {
+            var context = props.context || this.context;
+            href = context.makePath(routeName, props.navParams);
+        }
+        if (!href) {
+            throw new Error('NavLink created without href or routeName');
+        }
+        return href;
+    },
     dispatchNavAction: function (e) {
         debug('dispatchNavAction: action=NAVIGATE', this.props.href, this.props.followLink, this.props.navParams);
 
@@ -45,7 +67,7 @@ NavLink = React.createClass({
             return;
         }
 
-        var href = this.props.href;
+        var href = this.state.href;
 
         if (href[0] === '#') {
             // this is a hash link url for page's internal links.
@@ -67,37 +89,28 @@ NavLink = React.createClass({
             href = href.substring(origin.length) || '/';
         }
 
-        var context;
-        if (this.context && this.context.executeAction) {
-            context = this.context;
-        } else if (this.props.context && this.props.context.executeAction) {
-            context = this.props.context;
+        var context = this.props.context || this.context;
+        if (!context || !context.executeAction) {
+            console.warn('NavLink does not have access to executeAction. Link using browser default.');
+            return;
         }
 
-        if (context) {
-            e.preventDefault();
-            e.stopPropagation();
-            context.executeAction(navigateAction, {
-                type: 'click',
-                url: href,
-                params: this.props.navParams
-            });
-        } else {
-            console.warn('NavLink.dispatchNavAction: missing dispatcher, will load from server');
-        }
+        e.preventDefault();
+        e.stopPropagation();
+        context.executeAction(navigateAction, {
+            type: 'click',
+            url: href,
+            params: this.props.navParams
+        });
     },
     render: function() {
-        var context = this.props.context || this.context;
-        var routeName = this.props.routeName;
-        var newProps = {};
-        if (!this.props.href && routeName && context) {
-            newProps.href = context.makePath(routeName, this.props.navParams);
-        }
         return React.createElement(
             'a',
             objectAssign({}, {
                 onClick: this.dispatchNavAction
-            }, this.props, newProps),
+            }, this.props, {
+                href: this.state.href
+            }),
             this.props.children
         );
     }

--- a/lib/NavLink.js
+++ b/lib/NavLink.js
@@ -50,7 +50,7 @@ NavLink = React.createClass({
             href = context.makePath(routeName, props.navParams);
         }
         if (!href) {
-            throw new Error('NavLink created without href or routeName');
+            throw new Error('NavLink created without href or unresolvable routeName \'' + routeName + '\'');
         }
         return href;
     },

--- a/tests/unit/lib/NavLink-test.js
+++ b/tests/unit/lib/NavLink-test.js
@@ -83,8 +83,9 @@ describe('NavLink', function () {
         });
         it ('none defined', function () {
             var navParams = {a: 1, b: 2};
-            var link = ReactTestUtils.renderIntoDocument(NavLink( {navParams:navParams, context:contextMock}, React.DOM.span(null, "bar")));
-            expect(link.props.href).to.equal(undefined);
+            expect(function () {
+                ReactTestUtils.renderIntoDocument(NavLink( {navParams:navParams, context:contextMock}, React.DOM.span(null, "bar")));
+            }).to.throw();
         });
     });
 
@@ -112,6 +113,17 @@ describe('NavLink', function () {
                 expect(testResult.dispatch.payload.type).to.equal('click');
                 expect(testResult.dispatch.payload.url).to.equal('/foo');
                 expect(testResult.dispatch.payload.params).to.eql({a: 1, b: true});
+                done();
+            }, 10);
+        });
+        it ('context.executeAction called for routeNames', function (done) {
+            var link = ReactTestUtils.renderIntoDocument(NavLink( {routeName:"foo", context: contextMock}, React.DOM.span(null, "bar")));
+            link.context = contextMock;
+            ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
+            window.setTimeout(function () {
+                expect(testResult.dispatch.action).to.equal('NAVIGATE');
+                expect(testResult.dispatch.payload.type).to.equal('click');
+                expect(testResult.dispatch.payload.url).to.equal('/foo');
                 done();
             }, 10);
         });


### PR DESCRIPTION
Found an issue in the last release where the `routeName` prop was not being transformed into an href within `dispatchNavAction`. This was due to the change in not adding `href` to the props. This was causing errors to be thrown on the client.