### PR TITLE
Lock down to React 0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "setimmediate": "^1.0.2"
   },
   "peerDependencies": {
-    "react": ">=0.12.0 <=0.13.x"
+    "react": "0.13.x"
   },
   "devDependencies": {
     "chai": "^2.0.0",
@@ -37,8 +37,8 @@
     "lodash": "^3.2.0",
     "mocha": "^2.0.1",
     "precommit-hook": "^1.0.2",
-    "react": ">=0.12.0 <=0.13.x",
-    "react-tools": ">=0.12.0 <=0.13.x"
+    "react": "0.13.x",
+    "react-tools": "0.13.x"
   },
   "jshintConfig": {
     "node": true


### PR DESCRIPTION
* Lock down to React 0.13.0 to give npm 1.x users a way to use React 0.13 (currently broken in Fluxible 0.2.x due to peerDependency range being broken in npm 1.x)