### PR TITLE
Document that RouterMixin requires 'state.route'.

### DIFF
--- a/docs/router-mixin.md
+++ b/docs/router-mixin.md
@@ -5,12 +5,55 @@
 * execute navigate action and then dispatch `CHANGE_ROUTE_START` and `CHANGE_ROUTE_SUCCESS` or `CHANGE_ROUTE_FAILURE` events via flux dispatcher on window `popstate` events
 * [manage scroll position](#scroll-position-management) when navigating between pages
 
+Note that the RouterMixing reads your component's `state.route`; your component is responsible for setting this value.  Typically this would be done by setting up a store which listens for 'CHANGE_ROUTE_SUCCESS' events.
+
 ## Example Usage
 ```js
+// AppStateStore.js
+var createStore = require('fluxible/addons').createStore;
+module.exports = createStore({
+  storeName: 'AppStateStore',
+  handlers: {
+    'CHANGE_ROUTE_SUCCESS': 'onNavigate'
+  },
+  initialize: function() {
+    this.route = null;
+  },
+  dehydrate: function() {
+    return this.route;
+  },
+  rehydrate: function(state) {
+    this.route = state;
+  },
+  onNavigate: function(route) {
+    this.route = route;
+    return this.emitChange();
+  }
+});
+```
+
+```js
+// Application.jsx
 var RouterMixin = require('flux-router-component').RouterMixin;
+var AppStateStore = require('../stores/AppStateStore');
 
 var Application = React.createClass({
-    mixins: [RouterMixin],
+    mixins: [FluxibleMixin, RouterMixin],
+    
+    statics: {
+        storeListeners: [AppStateStore]
+    },
+    
+    getInitialState: function() {
+        return {route: this.getStore(AppStateStore).route};
+    };
+    
+    onChange: function() {
+        this.setState({
+            route: this.getStore(AppStateStore).route
+        });
+    };
+    
     ...
 });
 ```


### PR DESCRIPTION
It took me a long time to figure out how this was supposed to work.  I built an app which used the RouterMixin, but I wasn't setting my top component's `state.route`, which resulted in none of this actually working.  :P  The example doesn't make it clear that this is an explicit requirement.

It kind of feels like there should be a less clunky way to do this... But for now, documenting this is a good idea.